### PR TITLE
Add CTest demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,10 @@ The slides for this workshop can be found at [slides.pdf](slides.pdf)
 
 ### Exercises
 The exercises for the course can be found in the [demos](demos/) directory.
-These take the form of erroneous Python scripts for unit testing, designed to
-demonstrate the practical use of `pytest --last-failed`.
-
-### Worked Solutions
-Worked solutions for all of the exercises can be found in the
-[TODO](worked-solutions/) directory.
-These are for recapping after the course in case you missed anything, and
-contain example solutions.
+These take the form of:
+* Demonstrating how to use [CodeCarbon](https://codecarbon.io/) in Python.
+* Erroneous code for unit testing, designed to demonstrate the practical use of
+  `pytest --last-failed` and `ctest --rerun-failed`.
 
 
 ## Preparation and prerequisites
@@ -98,6 +94,7 @@ following:
   [Windows Terminal (windows only)](https://learn.microsoft.com/en-us/windows/terminal/),
   [iTerm (mac only)](https://iterm2.com/)
 - A Python 3 installation
+- [CMake](https://cmake.org/) (optional)
 
 If you require assistance or further information with any of these please reach
 out to us before the session.
@@ -160,6 +157,9 @@ With your virtual environment active, install the Python dependencies in the
 ```sh
 pip install -r requirements.txt
 ```
+
+Optionally, install [CMake](https://cmake.org/) by following the instructions on
+the [download page](https://cmake.org/download/).
 
 ## License
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -43,7 +43,7 @@ involve code found in this subdirectory.
 ## 4a. Pytest
 
 1. Take a look at [pytest_last_failed.py](pytest_last_failed.py).
-2. Run `pytest --verbose pytest_last_failed.py` and inspect the failures.
+2. Run `pytest --verbose` and inspect the failures.
 3. Track down each issue, running `pytest --verbose --last-failed` each time you
    make a fix. You should see that fewer tests are run each time.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,59 @@
+# Demos
+
+There are several demos that we encounter in the Green Software Engineering
+Practices course. Some of them involve navigating to a website and others
+involve code found in this subdirectory.
+
+## 1. CodeCarbon
+
+1. Take a look at [code_carbon.py](code_carbon.py).
+2. Replace the TODO note with some code to execute.
+3. Run the Python script to find out the associated emissions.
+
+> [!HINT]
+> Running with `python3 demos/code_carbon.py 2>codecarbon.log` will print
+> CodeCarbon's logging output to a separate file so that you can more clearly
+> see any print statements.
+
+4. Inspect the log file and the `emissions.csv` file that is produced.
+5. Launch the CodeCarbon dashboard to explore the results visually:
+   ```sh
+   carbonboard --filepath="emissions.csv" --port=3333
+   ```
+   Then open [http://localhost:3333](http://localhost:3333) in your browser. The
+   dashboard shows carbon equivalents (e.g. km driven, TV hours) and a global
+   map of energy mix by region.
+
+## 2. GreenAlgorithms calculator
+
+1. Navigate to the
+   [GreenAlgorithms calculator](https://calculator.green-algorithms.org/)
+2. Open this [paper](https://gmd.copernicus.org/articles/17/3081/2024/)
+   comparing the energy usage of different models participating in CMIP.
+3. Plug in numbers for different models
+
+## 3. Climate-Aware Task Scheduler
+
+1. Install the [CATS](https://github.com/GreenScheduler/cats) Python package.
+2. Query for the optimal time to run a 30 minute job in your postcode using the
+   `--duration` and `--location` flags.
+3. Plot the forecast using the `--plot` flag.
+4. What happens if you try a long job, e.g., 2800 mins?
+
+## 4a. Pytest
+
+1. Take a look at [pytest_last_failed.py](pytest_last_failed.py).
+2. Run `pytest --verbose pytest_last_failed.py` and inspect the failures.
+3. Track down each issue, running `pytest --verbose --last-failed` each time you
+   make a fix. You should see that fewer tests are run each time.
+
+## 4b. CTest
+
+Navigate to [ctest_rerun_failed](ctest_rerun_failed) and read the README there.
+
+## 5. AI footprint calculator
+
+1. Navigate to https://www.climatealigned.co/tools/ai-footprint-calculator
+2. Play around with the different options.
+3. Get a sense for your current footprint and how it would change with different
+   levels of AI usage.

--- a/demos/ctest_rerun_failed/CMakeLists.txt
+++ b/demos/ctest_rerun_failed/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Build system for CTest demo
+#
+# Compile with CMake as follows:
+#
+#    mkdir build
+#    cd build
+#    cmake ..
+#    cmake --build .
 cmake_minimum_required(VERSION 3.10)
 project(CTestRerunFailed)
 

--- a/demos/ctest_rerun_failed/CMakeLists.txt
+++ b/demos/ctest_rerun_failed/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10)
+project(CTestRerunFailed)
+
+# Build the library
+add_library(conversion conversion.c)
+
+# Add the test suite, linking to the library
+add_executable(test_c2f test_c2f.c)
+target_link_libraries(test_c2f conversion)
+add_executable(test_f2c test_f2c.c)
+target_link_libraries(test_f2c conversion)
+add_executable(test_c2f_inverse test_c2f_inverse.c)
+target_link_libraries(test_c2f_inverse conversion)
+add_executable(test_f2c_inverse test_f2c_inverse.c)
+target_link_libraries(test_f2c_inverse conversion)
+
+# Enable testing
+enable_testing()
+
+# Add tests
+add_test(NAME test_c2f COMMAND test_c2f)
+add_test(NAME test_f2c COMMAND test_f2c)
+add_test(NAME test_c2f_inverse COMMAND test_c2f_inverse)
+add_test(NAME test_f2c_inverse COMMAND test_f2c_inverse)

--- a/demos/ctest_rerun_failed/README.md
+++ b/demos/ctest_rerun_failed/README.md
@@ -1,0 +1,20 @@
+# CTest demo
+
+This example demonstrates how to use `ctest --rerun-failed` to run subsets of a
+test suite written using CTest.
+
+1. Take a look at the temperature conversion library in
+   [conversion.c](conversion.c). Don't modify it yet.
+2. Take a look at the accompanying test suite files with the pattern `test_*.c`.
+   Don't modify them yet.
+3. Compile the library and test suite using CMake:
+```sh
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
+4. Try running the test suite with `ctest --verbose` and inspect the failures.
+5. Track down each issue, recompiling and running
+   `ctest --verbose --rerun-failed` each time you make a fix. You should see
+   that fewer tests are run each time.

--- a/demos/ctest_rerun_failed/conversion.c
+++ b/demos/ctest_rerun_failed/conversion.c
@@ -1,0 +1,13 @@
+/*
+ * Library of functions for converting between Celsius and Fahrenheit
+ */
+
+/*
+ * Convert Celsius to Fahrenheit
+ */
+double c2f(double celsius) { return 9.0 * celsius / 5.0 + 32.0; }
+
+/*
+ * Convert Fahrenheit to Celsius
+ */
+double f2c(double fahrenheit) { return (fahrenheit - 32.0) * 5.0 / 8.0; }

--- a/demos/ctest_rerun_failed/test_c2f.c
+++ b/demos/ctest_rerun_failed/test_c2f.c
@@ -1,0 +1,16 @@
+/*
+ * Test conversion from Fahrenheit to Celsius.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "conversion.c"
+
+#define EPSILON 0.001
+
+int main() {
+  assert(fabs(f2c(32.0) - 1.0) < EPSILON);
+  assert(fabs(f2c(-40.0) - (-40.0)) < EPSILON);
+}

--- a/demos/ctest_rerun_failed/test_c2f_inverse.c
+++ b/demos/ctest_rerun_failed/test_c2f_inverse.c
@@ -1,0 +1,20 @@
+/*
+ * Test f2c is the inverse of c2f.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "conversion.c"
+
+#define EPSILON 0.001
+
+int main() {
+  double values[] = {0.0, 7.5, 23.0};
+  for (int i = 0; i < 3; i++) {
+    double fahrenheit = c2f(values[i]);
+    double celsius = f2c(fahrenheit);
+    assert(fabs(celsius - values[i]) < EPSILON);
+  }
+}

--- a/demos/ctest_rerun_failed/test_f2c.c
+++ b/demos/ctest_rerun_failed/test_f2c.c
@@ -1,0 +1,16 @@
+/*
+ * Test conversion from Celsius to Fahrenheit.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "conversion.c"
+
+#define EPSILON 0.001
+
+int main() {
+  assert(fabs(c2f(0.0) - 32.0) < EPSILON);
+  assert(fabs(c2f(-40.0) - (-40.0)) < EPSILON);
+}

--- a/demos/ctest_rerun_failed/test_f2c_inverse.c
+++ b/demos/ctest_rerun_failed/test_f2c_inverse.c
@@ -1,0 +1,20 @@
+/*
+ * Test f2c is the inverse of c2f.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "conversion.c"
+
+#define EPSILON 0.001
+
+int main() {
+  double values[] = {0.0, 7.5, 23.0};
+  for (int i = 0; i < 3; i++) {
+    double celsius = f2c(values[i]);
+    double fahrenheit = f2c(celsius);
+    assert(fabs(fahrenheit - values[i]) < EPSILON);
+  }
+}

--- a/demos/pytest_last_failed.py
+++ b/demos/pytest_last_failed.py
@@ -7,7 +7,7 @@ implementations and tests contain three errors.
 
 Exercises:
 
-1. Run `pytest --verbose demos/pytest_last_failed.py` to see the failures.
+1. Run `pytest --verbose pytest_last_failed.py` to see the failures.
 
 2. Track down each issue, running `pytest --verbose --last-failed` each time you make a
    fix. You should see that fewer tests are run each time.


### PR DESCRIPTION
Closes #11.

In addition to the Python-based `pytest --last-failed` demo added in #9, this PR adds an equivalent for `ctest --rerun-failed` in C.

The PR also adds READMEs to better structure and document the demos.